### PR TITLE
arcade screen mobile fixes

### DIFF
--- a/src/components/ArcadeCabinet/Controls.js
+++ b/src/components/ArcadeCabinet/Controls.js
@@ -8,11 +8,18 @@ class Controls extends React.Component {
 
   render() {
     return (
-      <div style={{ position: 'relative', top: '-20px', width: '100%', padding: '0 40px' }}>
+      <div style={{
+        position: 'relative',
+        width: '100%',
+        top: '-12px',
+        padding: '0 40px',
+        transform: 'translateZ(1px)'
+       }}>
         <button
           className="arcade-button left"
           aria-label="Arcade Left Button"
           onClick={this.props.onButtonLeft}
+          onTouchStart
           style={{
             backgroundImage: `url(${this.props.spriteSheetSrc})`,
             width: this.props.buttonWidth,
@@ -24,6 +31,7 @@ class Controls extends React.Component {
           className="arcade-button right"
           aria-label="Arcade Right Button"
           onClick={this.props.onButtonRight}
+          onTouchStart
           style={{
             backgroundImage: `url(${this.props.spriteSheetSrc})`,
             width: this.props.buttonWidth,

--- a/src/components/ArcadeCabinet/FullCabinet.js
+++ b/src/components/ArcadeCabinet/FullCabinet.js
@@ -31,9 +31,10 @@ class FullCabinet extends React.Component {
     let width = this.containerRef.current.offsetWidth;
     let height = width / this.props.screenAspectRatio;
 
-    if (window._arcadeScreen.isInitialized()) {
+    if (ArcadeScreenContext.getContext().isInitialized()) {
       ArcadeScreenContext.getContext().mount(this.containerRef.current, width, height);
-    } else {
+    }
+    else {
       this.containerRef.current.classList.add('fade');
       ArcadeScreenContext.getContext().mount(this.containerRef.current, width, height, () => {
         this.containerRef.current.classList.add('show');
@@ -64,8 +65,8 @@ class FullCabinet extends React.Component {
       (TOP_PANEL_HEIGHT_RATIO * ARCADE_CABINET_WIDTH) / ARCADE_CABINET_ASPECT_RATIO;
 
     let outerWidth = ARCADE_CABINET_WIDTH + arcadePadding * 2;
-    let screenWidth = outerWidth - arcadePadding * 2 - arcadePanelPaddingX * 2;
-    let screenHeight = screenWidth / this.props.screenAspectRatio;
+    let screenWidth = Math.ceil(outerWidth - arcadePadding * 2 - arcadePanelPaddingX * 2);
+    let screenHeight = Math.ceil(screenWidth / this.props.screenAspectRatio);
     return (
       <div
         aria-label="Arcade Cabinet"
@@ -101,7 +102,7 @@ class FullCabinet extends React.Component {
             ref={this.containerRef}
             style={{
               minWidth: screenWidth,
-              minHeight: screenHeight,
+              minHeight: screenHeight
             }}
           />
           <Controls

--- a/src/components/ArcadeCabinet/index.css
+++ b/src/components/ArcadeCabinet/index.css
@@ -7,6 +7,7 @@
 }
 
 #arcade-screen-container canvas {
+  display: block;
   transform: translateZ(1px);
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,7 +4,8 @@ body, html {
   height: 100%;
   margin: 0;
 }
-canvas {
+canvas,
+.arcade-cabinet {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;


### PR DESCRIPTION
- active state on mobile
- button correctly positioned before/after canvas is mounted
- disable text collection on entire arcade cabinet
- render buttons on top of screen