### PR TITLE
fade arcade-screen after arcade-cabinet image loads

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,9 +1,2 @@
 import "./src/styles/global.css"
 import "./src/styles/prism-perfect.css"
-
-import { ArcadeScreenContext } from './src/components/ArcadeScreen';
-export function onClientEntry() {
-  if (!ArcadeScreenContext.exists()) {
-    ArcadeScreenContext.createContext();
-  }
-}

--- a/src/components/ArcadeCabinet/Controls.js
+++ b/src/components/ArcadeCabinet/Controls.js
@@ -19,7 +19,7 @@ class Controls extends React.Component {
           className="arcade-button left"
           aria-label="Arcade Left Button"
           onClick={this.props.onButtonLeft}
-          onTouchStart
+          onTouchStart={() => null}
           style={{
             backgroundImage: `url(${this.props.spriteSheetSrc})`,
             width: this.props.buttonWidth,
@@ -31,7 +31,7 @@ class Controls extends React.Component {
           className="arcade-button right"
           aria-label="Arcade Right Button"
           onClick={this.props.onButtonRight}
-          onTouchStart
+          onTouchStart={() => null}
           style={{
             backgroundImage: `url(${this.props.spriteSheetSrc})`,
             width: this.props.buttonWidth,

--- a/src/components/ArcadeCabinet/FullCabinet.js
+++ b/src/components/ArcadeCabinet/FullCabinet.js
@@ -27,15 +27,16 @@ class FullCabinet extends React.Component {
     this.containerRef = React.createRef();
   }
 
-  componentDidMount() {
+  handleImageLoad() {
     let width = this.containerRef.current.offsetWidth;
     let height = width / this.props.screenAspectRatio;
 
-    if (ArcadeScreenContext.getContext().isInitialized()) {
+    if (ArcadeScreenContext.exists()) {
+      this.containerRef.current.classList.remove('fade');
       ArcadeScreenContext.getContext().mount(this.containerRef.current, width, height);
     }
     else {
-      this.containerRef.current.classList.add('fade');
+      ArcadeScreenContext.createContext();
       ArcadeScreenContext.getContext().mount(this.containerRef.current, width, height, () => {
         this.containerRef.current.classList.add('show');
       });
@@ -86,7 +87,8 @@ class FullCabinet extends React.Component {
         <Img
           fluid={this.props.arcadeCabinetImg}
           outerWrapperClassName="arcade-mask-outer-wrapper"
-          fadeIn={false}
+          fadeIn={true}
+          onLoad={() => this.handleImageLoad()}
         />
         <div
           className="arcade-panel-padding"
@@ -99,6 +101,7 @@ class FullCabinet extends React.Component {
         >
           <div
             id="arcade-screen-container"
+            className="fade"
             ref={this.containerRef}
             style={{
               minWidth: screenWidth,

--- a/src/components/ArcadeCabinet/index.css
+++ b/src/components/ArcadeCabinet/index.css
@@ -42,7 +42,7 @@
 /* <Img /> fade */
 .fade {
   opacity: 0;
-  transition: opacity 0.25s ease;
+  transition: opacity 0.5s ease;
 }
 
 .fade.show {


### PR DESCRIPTION
Removes the jank from page load.

Create context after the image loads instead of immediately. Before the page would stutter while the context was being created but now the context is created after the page is settled.

Context is created only once and if the context had been previously created skip the fade because everything will render instantly.