### PR TITLE
create context and renderer with initial size

### DIFF
--- a/src/components/ArcadeCabinet/FullCabinet.js
+++ b/src/components/ArcadeCabinet/FullCabinet.js
@@ -36,7 +36,7 @@ class FullCabinet extends React.Component {
       ArcadeScreenContext.getContext().mount(this.containerRef.current, width, height);
     }
     else {
-      ArcadeScreenContext.createContext();
+      ArcadeScreenContext.createContext(width, height);
       ArcadeScreenContext.getContext().mount(this.containerRef.current, width, height, () => {
         this.containerRef.current.classList.add('show');
       });

--- a/src/components/ArcadeScreen/ArcadeScreen.js
+++ b/src/components/ArcadeScreen/ArcadeScreen.js
@@ -6,7 +6,7 @@ import { clamp, getRandomRange, convertRange, waitUntilReady } from './utils';
 import { allPallettes, convertPalletteToHexStrings } from './ColorPallettes';
 
 export default class ArcadeScreen {
-  constructor() {
+  constructor(width, height) {
     this.aspectRatio = 3 / 4;
     this.currentPalletteIndex = 0;
 
@@ -19,7 +19,7 @@ export default class ArcadeScreen {
         return;
       }
 
-      this.arcadeScreenRenderer = new ArcadeScreenRenderer(this.aspectRatio);
+      this.arcadeScreenRenderer = new ArcadeScreenRenderer(this.aspectRatio, width, height);
       this.arcadeScreenRenderer.setColorPallette(allPallettes[this.currentPalletteIndex]);
       this.arcadeScreenRenderer
         .getCanvasElement()
@@ -58,7 +58,7 @@ export default class ArcadeScreen {
 
     if (canvas.parentElement) console.error('ArcadeScreen is already mounted!');
 
-    this.arcadeScreenRenderer.setSize(width, height);
+    // this.arcadeScreenRenderer.setSize(width, height);
     rootElement.append(this.arcadeScreenRenderer.getCanvasElement());
     this.animate(0);
     onMounted ? onMounted() : null;

--- a/src/components/ArcadeScreen/ArcadeScreenRenderer.js
+++ b/src/components/ArcadeScreen/ArcadeScreenRenderer.js
@@ -11,7 +11,7 @@ import { getRandomRange, convertRange, positionInSphere } from './utils';
 import TextBuilder from './TextBuilder';
 
 export default class ArcadeScreenRenderer {
-  constructor(aspectRatio) {
+  constructor(aspectRatio, width, height) {
     /** INIT **/
     this.scene = new THREE.Scene();
     this.clock = new THREE.Clock();
@@ -134,6 +134,7 @@ export default class ArcadeScreenRenderer {
       alpha: true,
     });
     this.renderer.setPixelRatio(window.devicePixelRatio);
+    this.renderer.setSize(width, height);
     this.composer = new THREE.EffectComposer(this.renderer);
     this.passes.forEach(pass => {
       this.composer.addPass(pass);

--- a/src/components/ArcadeScreen/index.js
+++ b/src/components/ArcadeScreen/index.js
@@ -9,9 +9,9 @@ export const ArcadeScreenContext = {
     return window._arcadeScreen;
   },
 
-  createContext() {
+  createContext(width, height) {
     if (this.exists()) console.warn('ArcadeScreenContext already exists');
 
-    window._arcadeScreen = new ArcadeScreen();
+    window._arcadeScreen = new ArcadeScreen(width, height);
   },
 };


### PR DESCRIPTION
Buffers are being resized twice - when the context is created and again when mounted.

This change prevents the double resize.